### PR TITLE
docs: macOS IOKit roadmap, implementation notes, and distribution RFC

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,55 @@
+# hiberpower Roadmap
+
+## Phase 1: macOS IOKit Native Support (Milestone #1)
+
+**Goal**: Run all diagnostic commands on macOS via IOKit SCSITaskUserClient.
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #3 | Platform abstraction layer | Open |
+| #4 | IOKit SCSI passthrough backend | Open |
+| #5 | macOS device discovery | Open |
+| #6 | macOS CI + test matrix | Open |
+| #7 | macOS binary distribution | Open |
+
+**Architecture**: Extract `sg_io.zig` → `src/platform/{scsi,linux,darwin}.zig`. All 4,100+ lines of portable Zig (CDB builders, XRAM logic, SMART parsing) remain untouched.
+
+**Reference**: LTFS IOKit implementation for SCSITaskUserClient pattern.
+
+## Phase 2: Cross-Platform Release Pipeline (v1.0)
+
+- GoReleaser 2.5+ with Zig cross-compilation
+- Static musl binaries for Linux (single binary, all distros)
+- macOS: dynamic link to IOKit.framework
+- GitHub Releases with SHA256 checksums + GPG signatures
+- Homebrew tap: `jesssullivan/hiberpower`
+
+## Phase 3: Package Manager Distribution (v1.1)
+
+- nixpkgs contribution (Zig build derivation)
+- AUR PKGBUILD
+- macOS notarized PKG installer
+
+## Phase 4: Expanded Distro Coverage (v1.2)
+
+- Fedora COPR / RPM spec
+- Debian PPA / DEB packaging
+- EPEL for RHEL/Rocky
+
+## Future: Scope Expansion
+
+The `hiberpower` name could grow beyond ASM2362 to cover:
+
+- **USB-SATA bridges**: JMicron, ASMedia 1352R diagnostics
+- **Standalone NVMe**: Direct NVMe health monitoring (no bridge)
+- **Firmware updates**: Bridge + NVMe firmware flash
+- **Hibernation analysis**: NTFS hiberfil.sys parsing (original use case)
+- **Device lifecycle**: TRIM, secure erase, power state management
+- **Additional vendors**: Realtek, JMS578, VL716 bridge support
+
+## Naming
+
+Current: `hiberpower-ntfs` (scoped to NTFS hibernation recovery)
+Proposed: `hiberpower` (general USB/NVMe bridge diagnostics suite)
+
+The rename reflects the tool's evolved scope while preserving the project's identity.

--- a/docs/MACOS-IOKIT.md
+++ b/docs/MACOS-IOKIT.md
@@ -1,0 +1,141 @@
+# macOS IOKit SCSI Passthrough — Implementation Notes
+
+## Overview
+
+macOS does not expose Linux-style SG_IO for SCSI passthrough. Instead, the IOKit framework provides `SCSITaskUserClient` for sending arbitrary SCSI CDBs to devices. This document captures the research and design decisions for adding macOS support to hiberpower.
+
+## Apple's Restriction (QA1179)
+
+> "Mac OS X by design does not support sending SCSI or ATA commands from an application to most storage devices unless the developer provides a custom kernel driver."
+
+**Workaround**: Force-unmount all volumes, then claim exclusive access via SCSITaskUserClient. This is the pattern used by LTFS tape drivers and has been proven to work for USB mass storage.
+
+## IOKit Architecture
+
+```
+Userspace (hiberpower)
+    │
+    ▼
+SCSITaskDeviceInterface (IOKit plugin)
+    │
+    ▼
+IOSCSIPeripheralDeviceType00 (kernel driver)
+    │
+    ▼
+IOUSBMassStorageDriver
+    │
+    ▼
+ASM236X USB-NVMe Bridge (hardware)
+    │
+    ▼
+NVMe SSD
+```
+
+## Implementation Pattern
+
+### 1. Device Discovery
+
+```c
+// Find the IOService for a BSD disk name (e.g., "disk4")
+CFMutableDictionaryRef match = IOBSDNameMatching(kIOMainPortDefault, 0, "disk4");
+io_service_t service = IOServiceGetMatchingService(kIOMainPortDefault, match);
+
+// Walk up the IORegistry to find IOSCSIPeripheralDeviceType00
+io_service_t scsi_device = find_parent_of_class(service, "IOSCSIPeripheralDeviceType00");
+```
+
+### 2. Exclusive Access
+
+```c
+IOCFPlugInInterface **plugin = NULL;
+SInt32 score;
+IOCreatePlugInInterfaceForService(scsi_device,
+    kIOSCSITaskDeviceUserClientTypeID,
+    kIOCFPlugInInterfaceID,
+    &plugin, &score);
+
+SCSITaskDeviceInterface **device = NULL;
+(*plugin)->QueryInterface(plugin,
+    CFUUIDGetUUIDBytes(kIOSCSITaskDeviceInterfaceID),
+    (LPVOID *)&device);
+
+// Must unmount all volumes first!
+IOReturn result = (*device)->ObtainExclusiveAccess(device);
+```
+
+### 3. Command Execution
+
+```c
+SCSITaskInterface **task = (*device)->CreateSCSITask(device);
+
+// Set CDB (works for vendor commands 0xE4, 0xE5, 0xE6, 0xE8)
+UInt8 cdb[16] = { 0xE6, ... };
+(*task)->SetCommandDescriptorBlock(task, cdb, kSCSICDBSize_16Byte);
+
+// Set data transfer
+IOVirtualRange range = { .address = (IOVirtualAddress)buffer, .length = size };
+(*task)->SetScatterGatherEntries(task, &range, 1, size, kSCSIDataTransfer_FromTargetToInitiator);
+
+(*task)->SetTimeoutDuration(task, 30000);
+
+// Execute
+SCSI_Sense_Data sense;
+SCSITaskStatus status;
+UInt64 transferred;
+(*task)->ExecuteTaskSync(task, &sense, &status, &transferred);
+```
+
+### 4. Cleanup
+
+```c
+(*task)->Release(task);
+(*device)->ReleaseExclusiveAccess(device);
+(*device)->Release(device);
+(*plugin)->Release(plugin);
+```
+
+## Zig FFI Strategy
+
+```zig
+const c = @cImport({
+    @cInclude("IOKit/IOKitLib.h");
+    @cInclude("IOKit/IOCFPlugIn.h");
+    @cInclude("IOKit/scsi/SCSITaskLib.h");
+    @cInclude("CoreFoundation/CoreFoundation.h");
+});
+```
+
+In `build.zig`:
+```zig
+if (target.os_tag == .macos) {
+    exe.linkFramework("IOKit");
+    exe.linkFramework("CoreFoundation");
+}
+```
+
+## Error Mapping
+
+| IOKit Return Code | → SgError |
+|-------------------|-----------|
+| `kIOReturnSuccess` | (no error) |
+| `kIOReturnNotPermitted` | `PermissionDenied` |
+| `kIOReturnTimeout` | `Timeout` |
+| `kIOReturnNoDevice` | `DeviceNotFound` |
+| `kIOReturnExclusiveAccess` | `DeviceOpenFailed` (already locked) |
+| SCSI CHECK CONDITION | `CheckCondition` (reuse sense.zig) |
+
+## Permissions
+
+- **Requires sudo/root** for `ObtainExclusiveAccess`
+- **Device must be unmounted** before exclusive access
+- No SIP restrictions on IOKit SCSI access
+- No entitlements required for command-line tools
+
+## References
+
+- [LTFS macOS IOKit](https://github.com/amiaopensource/ltfs/blob/master/ltfs/src/tape_drivers/osx/iokit/iokit_scsi_base.c) — production implementation
+- [SCSITaskLib.h](https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.2.8.sdk/System/Library/Frameworks/IOKit.framework/Versions/A/Headers/scsi-commands/SCSITaskLib.h)
+- [SCSITaskUserClient source](https://github.com/aosm/IOSCSIArchitectureModelFamily/blob/master/UserClient/SCSITaskUserClient.cpp)
+- [Apple Mass Storage Driver Guide](https://developer.apple.com/library/archive/documentation/DeviceDrivers/Conceptual/MassStorage/06_LUD_Example/MS_LUD_Example.html)
+- [smartmontools os_darwin.cpp](https://www.smartmontools.org/) — IOKit device discovery
+- [Apple QA1179](https://developer.apple.com/library/archive/qa/qa1179/_index.html) — SCSI passthrough restrictions

--- a/docs/RFC-DISTRIBUTION.md
+++ b/docs/RFC-DISTRIBUTION.md
@@ -1,0 +1,145 @@
+# RFC: hiberpower Cross-Platform Distribution
+
+**Status**: Draft
+**Author**: Jess Sullivan
+**Date**: 2026-03-29
+
+## Motivation
+
+hiberpower is currently distributed as source-only, requiring users to install Zig and build from source. As macOS support is added and the tool's scope expands beyond ASM2362 NTFS recovery, a proper distribution strategy is needed.
+
+## Proposed Name
+
+**`hiberpower`** (dropping `-ntfs` suffix)
+
+Rationale: The tool has evolved from NTFS hibernation file recovery to a general-purpose USB-NVMe bridge diagnostic suite. The shorter name is:
+- Easier to type as a CLI command
+- Not misleading about scope
+- Available on most package registries
+
+## Platform Matrix
+
+| Target | Binary Type | Notes |
+|--------|-------------|-------|
+| `x86_64-linux-musl` | Static | Single binary for all Linux distros |
+| `aarch64-linux-musl` | Static | ARM64 Linux (Raspberry Pi, servers) |
+| `x86_64-macos` | Dynamic | Links IOKit.framework |
+| `aarch64-macos` | Dynamic | Apple Silicon |
+
+Linux uses musl static linking to eliminate glibc version dependency. macOS requires dynamic linking to IOKit.framework for SCSI passthrough.
+
+## Distribution Channels
+
+### Tier 1: Immediate (v1.0)
+
+**GitHub Releases**
+- Cross-compiled binaries for all 4 platforms
+- SHA256 checksums with GPG signature
+- GoReleaser 2.5+ orchestration (native Zig support)
+- Triggered by `git tag v*`
+
+**Homebrew Tap**
+```bash
+brew tap jesssullivan/hiberpower
+brew install hiberpower
+```
+
+Formula auto-detects platform (Intel vs Apple Silicon).
+
+### Tier 2: Community (v1.1)
+
+**nixpkgs**
+```nix
+{ lib, stdenv, fetchFromGitHub, zig }:
+stdenv.mkDerivation {
+  pname = "hiberpower";
+  version = "1.0.0";
+  src = fetchFromGitHub { owner = "Jesssullivan"; repo = "hiberpower"; ... };
+  nativeBuildInputs = [ zig ];
+  buildPhase = "zig build -Doptimize=ReleaseSafe --prefix $out";
+  meta.platforms = lib.platforms.unix;
+}
+```
+
+**AUR (Arch Linux)**
+```bash
+yay -S hiberpower
+```
+
+### Tier 3: Enterprise (v1.2)
+
+**Fedora COPR / RPM**
+- RPM spec file in `packaging/rpm/hiberpower.spec`
+- Submit to COPR for Fedora/RHEL/Rocky
+
+**Debian PPA / DEB**
+- debian/ directory with control, rules, changelog
+- Launchpad PPA for Ubuntu
+
+**EPEL**
+- For RHEL/CentOS/Rocky enterprise use
+- Requires Fedora package review first
+
+### macOS Notarization
+
+CLI binaries cannot be notarized directly. Options:
+1. **PKG installer** — `pkgbuild` + `notarytool submit` + `stapler staple`
+2. **DMG wrapping** — Less ideal for CLI tools
+3. **Skip notarization** — Users get Gatekeeper warning, dismissable for signed binaries
+
+Recommendation: PKG installer for official releases, raw binary in tar.gz for power users.
+
+## CI/CD Pipeline
+
+```yaml
+# .github/workflows/release.yml
+name: Release
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-linux-musl
+            runner: ubuntu-latest
+          - target: aarch64-linux-musl
+            runner: ubuntu-latest
+          - target: x86_64-macos
+            runner: macos-13
+          - target: aarch64-macos
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v1
+      - run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseSafe
+      - uses: actions/upload-artifact@v4
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+      - run: sha256sum hiberpower-* > checksums.txt
+      - uses: softprops/gh-release@v2
+```
+
+## Future Scope
+
+The distribution infrastructure should accommodate expansion to:
+- Additional bridge chipsets (JMicron, Realtek, VL716)
+- Standalone NVMe diagnostics
+- Firmware update capabilities
+- Windows support (if demand warrants)
+
+## Decision Log
+
+| Decision | Rationale |
+|----------|-----------|
+| Static musl for Linux | Eliminates glibc version matrix |
+| GoReleaser for CI | Native Zig support, single config |
+| Homebrew over MacPorts | Larger user base, simpler formula |
+| PKG for macOS notarization | Only staple-able format for CLI |
+| nixpkgs PR over flake-only | Broader discoverability |


### PR DESCRIPTION
## Summary
- `ROADMAP.md`: Phased plan from IOKit support through cross-platform packaging
- `docs/MACOS-IOKIT.md`: SCSITaskUserClient implementation reference (LTFS pattern, Zig FFI, error mapping)
- `docs/RFC-DISTRIBUTION.md`: Cross-platform CLI packaging strategy (Homebrew, nixpkgs, AUR, RPM, DEB)

Accompanies milestone #1 (macOS IOKit Native Support) and issues #3-#7.

## Context
PZM external SSD uses ASM2362 bridge (VID 0x174C, PID 0x2362). macOS smartmontools confirms NVMe Identify works over IOKit, but SMART log and vendor commands (0xE4/E5/E6 XRAM) are blocked by Apple's SCSI passthrough restriction. The LTFS tape driver pattern (force-unmount + SCSITaskUserClient) provides a proven workaround.