### PR TITLE
Add config-read and document post-recovery transport failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,11 @@ That is a distinct failure class from the earlier `Medium not present` controlle
 
 A later April 2026 field retest found a third failure class worth separating
 from both of those: the recovered enclosure can still advertise USB 3.x
-capability while negotiating only High Speed (`480Mbps`) across multiple hosts.
-See [docs/notes/usb-link-negotiation-field-report-2026-04.md](docs/notes/usb-link-negotiation-field-report-2026-04.md).
+capability while negotiating only High Speed (`480Mbps`) on a bad signal path.
+The follow-up reference-cable test on `petting-zoo-mini` negotiated
+`10Gbps (SuperSpeed+)`, which points at cable class / signal integrity rather
+than a global firmware lock to USB 2.0. See
+[docs/notes/usb-link-negotiation-field-report-2026-04.md](docs/notes/usb-link-negotiation-field-report-2026-04.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,25 @@ zig build test-all   # all module tests (sg_io, sense, passthrough, replay, xram
 
 ---
 
+## Post-Recovery Darwin Integration
+
+Recovery on Linux does not automatically mean the enclosure is ready as a managed macOS automation target.
+
+On 2026-04-12, the same recovered ASM2362 + NVMe path:
+
+- behaved normally on Linux (`probe` ready, normal capacity, read/write smoke test passed)
+- could be reformatted to APFS and auto-mounted on macOS
+- still returned `Operation not permitted` from `sshd` and one-shot `launchd` contexts on `petting-zoo-mini`
+
+That is a distinct failure class from the earlier `Medium not present` controller-protection state. See [docs/notes/darwin-post-recovery-integration.md](docs/notes/darwin-post-recovery-integration.md).
+
+A later April 2026 field retest found a third failure class worth separating
+from both of those: the recovered enclosure can still advertise USB 3.x
+capability while negotiating only High Speed (`480Mbps`) across multiple hosts.
+See [docs/notes/usb-link-negotiation-field-report-2026-04.md](docs/notes/usb-link-negotiation-field-report-2026-04.md).
+
+---
+
 ## Project Structure
 
 ```

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,7 +8,7 @@ This directory contains research notes, analysis, and workflow documentation for
 |----------|-------------|
 | [debug-session-summary.md](notes/debug-session-summary.md) | Hardware stack identification, ASM2362 bridge detection |
 | [darwin-post-recovery-integration.md](notes/darwin-post-recovery-integration.md) | Cross-platform note: recovered media can still fail Darwin automation access |
-| [usb-link-negotiation-field-report-2026-04.md](notes/usb-link-negotiation-field-report-2026-04.md) | Field report: recovered enclosure still negotiating only 480Mbps despite advertising USB 3.x capability |
+| [usb-link-negotiation-field-report-2026-04.md](notes/usb-link-negotiation-field-report-2026-04.md) | Field report: recovered enclosure negotiated only 480Mbps on bad signal paths, then reached 10Gbps with a dedicated SuperSpeed cable |
 | [diagnosis-findings.md](notes/diagnosis-findings.md) | Silent write failure evidence, test methodology |
 | [hardware-test-results.md](notes/hardware-test-results.md) | asm2362-tool probe/identify command outputs |
 | [linux-kernel-investigation.md](notes/linux-kernel-investigation.md) | Linux block layer, USB storage, SCSI translation analysis |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,8 @@ This directory contains research notes, analysis, and workflow documentation for
 | Document | Description |
 |----------|-------------|
 | [debug-session-summary.md](notes/debug-session-summary.md) | Hardware stack identification, ASM2362 bridge detection |
+| [darwin-post-recovery-integration.md](notes/darwin-post-recovery-integration.md) | Cross-platform note: recovered media can still fail Darwin automation access |
+| [usb-link-negotiation-field-report-2026-04.md](notes/usb-link-negotiation-field-report-2026-04.md) | Field report: recovered enclosure still negotiating only 480Mbps despite advertising USB 3.x capability |
 | [diagnosis-findings.md](notes/diagnosis-findings.md) | Silent write failure evidence, test methodology |
 | [hardware-test-results.md](notes/hardware-test-results.md) | asm2362-tool probe/identify command outputs |
 | [linux-kernel-investigation.md](notes/linux-kernel-investigation.md) | Linux block layer, USB storage, SCSI translation analysis |

--- a/docs/notes/darwin-post-recovery-integration.md
+++ b/docs/notes/darwin-post-recovery-integration.md
@@ -1,0 +1,115 @@
+# Darwin Post-Recovery Integration Notes
+
+**Date**: 2026-04-12
+
+## Why This Note Exists
+
+The original recovery work in this repo was about a controller/bridge/media failure class: a drive behind an ASM2362 bridge that had fallen into a `Medium not present` / zero-capacity protected state and was later recovered via XRAM command injection.
+
+This note records a separate, later problem that showed up after recovery:
+
+- the recovered drive and enclosure are healthy on Linux
+- the same enclosure is usable as an APFS target on macOS
+- but some macOS execution contexts still cannot access that mounted APFS volume for automation work
+
+That distinction matters. “Recovered drive” is not the same as “operationally usable target on every host and execution model.”
+
+## 2026-04-12 Cross-Platform Findings
+
+### Linux on `yoga`
+
+The recovered enclosure path behaves normally:
+
+- ASM2362 bridge enumerates cleanly as `174c:2362`
+- `asm2362-tool probe` reports `READY` with normal capacity
+- `blkid` identifies the volume normally
+- `fsck.exfat -n` reported a clean filesystem before macOS reformat
+- read-only mount succeeded
+- small read/write/delete smoke test succeeded
+
+Important nuance:
+
+- `asm2362-tool identify` and `smart` returned `Invalid command`
+- `smartctl -d sntasmedia` returned unsupported opcode
+
+That looks like a passthrough limitation on this bridge path, not a return to the earlier protected-state failure.
+
+### macOS on `petting-zoo-mini`
+
+The media and mount path were eventually normalized successfully:
+
+- the external device was reformatted to APFS as `TinylandSSD`
+- the volume auto-mounted back to `/Volumes/TinylandSSD` across reboot
+- `diskutil enableOwnership` succeeded
+
+But the real automation contexts still failed:
+
+- the first remote context probe showed both `sshd` and one-shot user `launchd` failing SSD writes with `Operation not permitted`
+- after `tinyland-cleanup` was moved to a stable launchd path, the failure split became sharper:
+  - interactive shell: list/read works, but `xattr` and write/delete time out
+  - launchd user agent: list/read works, but `xattr` and write/delete still fail fast with `Operation not permitted`
+- the stable cleanup binary is now at `/Users/jsullivan2/.local/bin/tinyland-cleanup` with identifier `dev.tinyland.tinyland-cleanup`
+- the stable cleanup binary is now Developer ID signed (`TeamIdentifier=QP994XQKNH`)
+- Developer ID signing did not change the SSD access outcome, so the remaining issue is Darwin grant state rather than signing mechanics
+- the first direct signed `tinyland-cleanup` probe also exposed a separate Darwin packaging trap:
+  - a Developer ID-signed Nix-linked Go build failed at launch because dyld rejected a differently-signed `/nix/store` `libresolv` dependency
+  - rebuilding the standalone binary with `CGO_ENABLED=0` removed the `/nix/store` dylib dependency and avoided that launch failure
+- a stable signed direct-syscall helper at `~/.local/bin/tinyland-volume-access-probe` sharpened the picture further:
+  - `listxattr` succeeds
+  - direct directory open and create still time out
+  - `sample` on the hanging helper child shows it blocked in `open$NOCANCEL` from `__opendir2`
+- the real `tinyland-cleanup` consumer now reproduces the same lower-level stall directly:
+  - interactive and one-shot launchd probe modes both time out on directory open and write/delete while `xattr` succeeds
+  - `sample` on the real consumer child shows it blocked in `open` from the Go runtime syscall path
+- a one-shot local root `LaunchDaemon` on macOS reproduces the same timeout shape and attributes the policy query directly to the final consumer binary
+- that rules out remote-session wrapper noise as the main explanation
+- an internal APFS control path on the same host passes cleanly in the same consumer contexts
+- that means the remaining Darwin issue is specific to the external path rather than the recovered media being generically unusable on macOS
+- platform binaries in a local root LaunchDaemon also fail immediately on the external path while passing on the internal control path
+- that suggests the external path is provoking both fast system-policy denials for platform binaries and a separate hanging `open` path for the non-platform cleanup consumer
+- `crush-dots` now carries a bounded storage-log helper and a local-console runbook for this phase, which is the right place to keep pushing the Darwin-side investigation
+- `crush-dots` now also carries a PPPC profile scaffold for the stable `tinyland-cleanup` binary:
+  - live identity export
+  - a renderer for `com.apple.TCC.configuration-profile-policy`
+  - a narrow-first `SystemPolicyRemovableVolumes` example profile
+  - this moves the next Darwin tranche onto the supported managed-profile path instead of more shell-only grant attempts
+
+That means the remaining problem is no longer bridge/media recovery. It is a Darwin execution-context access-policy problem.
+
+## Interpretation
+
+This should not be misclassified as a new storage failure.
+
+A later note covers a separate transport-debug lane where the same recovered
+enclosure negotiates only `480Mbps` despite still advertising USB 3.x
+capability. See
+[usb-link-negotiation-field-report-2026-04.md](usb-link-negotiation-field-report-2026-04.md).
+
+What it is:
+
+- recovered media
+- healthy Linux read/write path
+- healthy APFS mount and reboot persistence on macOS
+- unhealthy Darwin automation access from specific contexts
+
+What it is not:
+
+- the original `Medium not present` / zero-capacity controller-protection case
+- proof that the bridge or NVMe media is still broken
+
+## Implications For This Repo
+
+`hiberpower-ntfs` should explicitly acknowledge a post-recovery class of work:
+
+- distinguishing bridge passthrough limits from actual dead media
+- distinguishing Linux usability from macOS automation usability
+- treating Darwin access-policy validation as a separate integration phase after media recovery
+- recognizing that stable executable path is necessary but may still leave both a signing/grant-identity problem and a Darwin packaging/linkage problem on macOS
+
+This repo does not need to own the Darwin automation rollout itself, but it should document the boundary clearly enough that future investigation does not regress into “the drive must be broken again.”
+
+## Follow-On Work
+
+- keep Linux-side `asm2362-tool probe` as the quick discriminator between recovered media and the old protected-state failure
+- document the macOS side as an access-policy / consumer-context problem
+- coordinate with `crush-dots` for the actual launchd / codesign / stable-path rollout work on `petting-zoo-mini`

--- a/docs/notes/darwin-post-recovery-integration.md
+++ b/docs/notes/darwin-post-recovery-integration.md
@@ -81,8 +81,10 @@ That means the remaining problem is no longer bridge/media recovery. It is a Dar
 This should not be misclassified as a new storage failure.
 
 A later note covers a separate transport-debug lane where the same recovered
-enclosure negotiates only `480Mbps` despite still advertising USB 3.x
-capability. See
+enclosure initially negotiated only `480Mbps` despite still advertising USB 3.x
+capability. A later `petting-zoo-mini` retest with a dedicated SuperSpeed cable
+negotiated `10Gbps (SuperSpeed+)`, so that lane now points at cable class /
+signal integrity before firmware mutation. See
 [usb-link-negotiation-field-report-2026-04.md](usb-link-negotiation-field-report-2026-04.md).
 
 What it is:

--- a/docs/notes/usb-link-negotiation-field-report-2026-04.md
+++ b/docs/notes/usb-link-negotiation-field-report-2026-04.md
@@ -1,0 +1,138 @@
+# USB Link Negotiation Field Report (April 2026)
+
+**Date**: 2026-04-22
+
+## Why This Note Exists
+
+This note captures a third failure class for the recovered ASM2362 + NVMe path.
+
+This repo already documents two distinct states:
+
+- the original controller-protection failure (`Medium not present`, zero/invalid
+  capacity, blocked admin path)
+- the later Darwin automation / access-policy problem, where recovered media is
+  usable but some macOS execution contexts cannot operate on the mounted APFS
+  volume
+
+This note records a separate transport problem seen during fresh field retests:
+
+- the bridge advertises USB 3.x capability
+- the media reports normal capacity and remains readable
+- but the negotiated USB link falls back to **High Speed / 480Mbps**
+
+That should not be confused with the original recovery failure.
+
+## Current Field Findings
+
+### macOS Hosts
+
+Two separate macOS hosts showed the same transport ceiling on direct USB-C
+paths:
+
+- bridge fingerprint remained `174c:2362` / `ASM236X series`
+- the external disk still mounted normally as APFS
+- live USB inspection still reported `UsbLinkSpeed=480000000`
+- `Device Speed=2` remained the negotiated state
+
+Interpretation:
+
+- the enclosure is still usable enough to enumerate and mount
+- but it is not reaching a healthy SuperSpeed path on either tested Mac
+
+### Linux Host With USB-C to USB-A Path
+
+On a Linux laptop using a dedicated USB-C to USB-A cable connected directly to a
+port marked for SuperSpeed:
+
+- `lsusb -t` still placed the ASM2362 on the USB 2.0 tree at `480M`
+- the enclosure bound `usb-storage`, not a higher-speed path
+- the NVMe still appeared normally as `/dev/sda`
+
+Most important detail:
+
+- `lsusb -v -d 174c:2362` showed that the bridge still advertises:
+  - `SuperSpeed (5Gbps)`
+  - `SuperSpeedPlus (10Gb/s)`
+- but the **negotiated** speed still landed at `High Speed (480Mbps)`
+
+Interpretation:
+
+- the bridge does not currently look like it has collapsed into a permanently
+  USB-2-only descriptor personality
+- the current failure looks more like link negotiation or signal-path
+  degradation than a dead media/controller relapse
+
+## Read-Only Bridge Probes On The 480Mbps Path
+
+Read-only `hiberpower-ntfs` probes on the Linux `480M` path sharpen the
+distinction further:
+
+- `asm2362-tool probe /dev/sda`
+  - `READY`
+  - normal `256060514304`-byte capacity
+  - normal SCSI identity (`ASMT 2360 NVME`)
+- `asm2362-tool config-read /dev/sda --image=0`
+  - succeeded
+- `asm2362-tool config-read /dev/sda --image=1`
+  - succeeded
+- `asm2362-tool xram-probe /dev/sda`
+  - succeeded
+  - could read XRAM, the live Admin Submission Queue, and PCIe MMIO
+- `asm2362-tool identify /dev/sda`
+  - failed with `Invalid command`
+- `asm2362-tool smart /dev/sda --json`
+  - failed with `Invalid command`
+- `smartctl -d sntasmedia -i -H /dev/sda`
+  - failed with unsupported opcode
+
+Those failures match the later healthy-Linux notes in this repo more closely
+than the older `Medium not present` failure class.
+
+Interpretation:
+
+- the bridge is still alive enough for read-only vendor XRAM access
+- the media still presents normal capacity
+- the current `480Mbps` state does **not** look like a return to the original
+  recovery problem
+
+## What This Does Not Prove
+
+This evidence does **not** prove that the cable is good.
+
+It only narrows the explanation:
+
+- it weakens "the bridge is back in the old dead/protected state"
+- it weakens "the firmware only exposes a USB-2-only personality now"
+- it does **not** eliminate:
+  - cable quality or cable class
+  - connector wear
+  - host port signal path
+  - enclosure hardware degradation
+
+## Golden Cable Trifecta
+
+The cleanest next validation step is a known-good reference matrix:
+
+1. one short, known-good `USB-C ↔ USB-C` cable
+2. one short, known-good `USB-A ↔ USB-C` cable
+3. the same enclosure tested across three host paths:
+   - Apple Silicon Mac host A
+   - Apple Silicon Mac host B
+   - Linux host with USB-A path
+
+Success criterion:
+
+- any test that negotiates at `5000M` or better proves the current path is not
+  inherently locked to USB 2.0
+
+Failure criterion:
+
+- if the same enclosure still negotiates only `480Mbps` across all three
+  reference paths, the enclosure / bridge hardware becomes the primary suspect
+
+## Relationship To Other Notes
+
+- For the original recovery failure, see
+  [hardware-test-results.md](hardware-test-results.md)
+- For the post-recovery Darwin automation / policy problem, see
+  [darwin-post-recovery-integration.md](darwin-post-recovery-integration.md)

--- a/docs/notes/usb-link-negotiation-field-report-2026-04.md
+++ b/docs/notes/usb-link-negotiation-field-report-2026-04.md
@@ -1,6 +1,7 @@
 # USB Link Negotiation Field Report (April 2026)
 
 **Date**: 2026-04-22
+**Updated**: 2026-04-27 EDT
 
 ## Why This Note Exists
 
@@ -21,6 +22,30 @@ This note records a separate transport problem seen during fresh field retests:
 - but the negotiated USB link falls back to **High Speed / 480Mbps**
 
 That should not be confused with the original recovery failure.
+
+## Resolution Update: Dedicated SuperSpeed Cable
+
+On 2026-04-27 EDT, the same `petting-zoo-mini` enclosure path was retested with
+a dedicated SuperSpeed-rated USB-C cable. That changed the result materially:
+
+- macOS enumerated one external physical disk
+- the expected `Asmedia` / `ASM236X` fingerprint was visible
+- the negotiated link reported `10Gbps (SuperSpeed+)`
+- `/Volumes/TinylandSSD` resolved as APFS on `disk8s1`, container `disk8`,
+  physical store `disk7s2`
+- bounded `diskutil` probes for the volume, synthesized container, and physical
+  store all returned successfully
+- `/Volumes/TinylandSSD/tinyland` existed as the Tinyland-owned writable
+  subtree and passed write/read/delete smoke
+
+Interpretation:
+
+- the earlier `480Mbps` state was a real link/signal-path failure
+- a dedicated SuperSpeed cable fixed the `petting-zoo-mini` path
+- the pzm evidence no longer supports "firmware is globally locked to USB 2.0"
+  as the primary explanation
+- descriptor/config tooling is still useful for diagnostics, but cable class
+  and signal path should be checked before firmware mutation
 
 ## Current Field Findings
 
@@ -109,9 +134,9 @@ It only narrows the explanation:
   - host port signal path
   - enclosure hardware degradation
 
-## Golden Cable Trifecta
+## Golden Cable Result
 
-The cleanest next validation step is a known-good reference matrix:
+The original next validation step was a known-good reference matrix:
 
 1. one short, known-good `USB-C ↔ USB-C` cable
 2. one short, known-good `USB-A ↔ USB-C` cable
@@ -129,6 +154,15 @@ Failure criterion:
 
 - if the same enclosure still negotiates only `480Mbps` across all three
   reference paths, the enclosure / bridge hardware becomes the primary suspect
+
+Current result:
+
+- the known-good USB-C to USB-C path on `petting-zoo-mini` negotiated
+  `10Gbps (SuperSpeed+)`
+- that is enough to reject the strongest "always USB 2.0" firmware hypothesis
+  for this enclosure
+- the remaining optional matrix work is useful for port/cable inventory, but it
+  is no longer blocking the pzm SSD lane
 
 ## Relationship To Other Notes
 

--- a/scripts/analysis/capture-asm2362-descriptors.sh
+++ b/scripts/analysis/capture-asm2362-descriptors.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Capture a read-only ASM2362 descriptor/config bundle on Linux.
+# Purpose: standardize the artifact set needed to compare degraded vs healthy
+# transport states for the same enclosure/firmware path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+OUTPUT_DIR="${OUTPUT_DIR:-$PROJECT_DIR/data/captures/asm2362-descriptor-$TIMESTAMP}"
+VIDPID="${VIDPID:-174c:2362}"
+DEVICE="${1:-}"
+
+mkdir -p "$OUTPUT_DIR"
+
+TOOL=""
+if [ -x "$PROJECT_DIR/zig-out/bin/asm2362-tool" ]; then
+    TOOL="$PROJECT_DIR/zig-out/bin/asm2362-tool"
+elif command -v asm2362-tool >/dev/null 2>&1; then
+    TOOL="$(command -v asm2362-tool)"
+fi
+
+run_capture() {
+    local name="$1"
+    shift
+    local file="$OUTPUT_DIR/$name.txt"
+
+    {
+        printf '$'
+        for arg in "$@"; do
+            printf ' %q' "$arg"
+        done
+        printf '\n'
+        "$@"
+    } >"$file" 2>&1 || true
+}
+
+maybe_capture() {
+    local probe="$1"
+    shift
+    local name="$1"
+    if command -v "$probe" >/dev/null 2>&1; then
+        run_capture "$@"
+    else
+        printf 'missing command: %s\n' "$probe" >"$OUTPUT_DIR/$name.txt"
+    fi
+}
+
+{
+    echo "ASM2362 Descriptor Bundle"
+    echo "timestamp=$TIMESTAMP"
+    echo "vidpid=$VIDPID"
+    if [ -n "$DEVICE" ]; then
+        echo "device=$DEVICE"
+    fi
+    if [ -n "$TOOL" ]; then
+        echo "tool=$TOOL"
+    else
+        echo "tool=missing"
+    fi
+} >"$OUTPUT_DIR/manifest.txt"
+
+echo "=== ASM2362 Descriptor Bundle ==="
+echo "Output: $OUTPUT_DIR"
+echo "VID:PID: $VIDPID"
+if [ -n "$DEVICE" ]; then
+    echo "Block device: $DEVICE"
+fi
+echo ""
+
+maybe_capture lsusb lsusb lsusb
+maybe_capture lsusb lsusb_tree lsusb -t
+maybe_capture lsusb lsusb_verbose lsusb -v -d "$VIDPID"
+maybe_capture usb-devices usb_devices usb-devices
+
+if [ -n "$DEVICE" ]; then
+    maybe_capture lsblk lsblk lsblk -o NAME,SIZE,MODEL,TRAN,VENDOR,SERIAL "$DEVICE"
+    maybe_capture udevadm udevadm udevadm info --query=all --name "$DEVICE"
+    maybe_capture smartctl smartctl_info smartctl -d sntasmedia -i "$DEVICE"
+fi
+
+if [ -n "$TOOL" ] && [ -n "$DEVICE" ]; then
+    run_capture asm_probe "$TOOL" probe "$DEVICE"
+    run_capture asm_config_image0 "$TOOL" config-read "$DEVICE" --image=0
+    run_capture asm_config_image1 "$TOOL" config-read "$DEVICE" --image=1
+fi
+
+echo "Bundle complete."
+echo ""
+echo "Key files:"
+echo "  $OUTPUT_DIR/lsusb_tree.txt"
+echo "  $OUTPUT_DIR/lsusb_verbose.txt"
+if [ -n "$DEVICE" ]; then
+    echo "  $OUTPUT_DIR/asm_config_image0.txt"
+    echo "  $OUTPUT_DIR/asm_config_image1.txt"
+fi

--- a/src/asm2362/config.zig
+++ b/src/asm2362/config.zig
@@ -1,0 +1,119 @@
+//! ASM2362 bridge configuration access.
+//!
+//! The ASM2362 exposes vendor-specific SCSI opcodes for configuration access:
+//! - 0xE0: Read config image (128 bytes)
+//! - 0xE1: Write config image (not implemented here yet)
+
+const std = @import("std");
+const sg_io = @import("../scsi/sg_io.zig");
+
+pub const CONFIG_SIZE: usize = 128;
+pub const IMAGE_COUNT: u8 = 2;
+
+pub const ConfigError = error{
+    PermissionDenied,
+    DeviceNotFound,
+    Timeout,
+    InvalidImageIndex,
+    CommandFailed,
+    ShortRead,
+};
+
+pub const ConfigReadResult = struct {
+    image_index: u8,
+    data: [CONFIG_SIZE]u8,
+    duration_ms: u32,
+    scsi_status: sg_io.ScsiStatus,
+};
+
+/// Build a READ CONFIG CDB (0xE0).
+///
+/// Source: cyrozap/usb-to-pcie-re ASM2x6x notes:
+///   e0 <image> 00 00 00 00
+pub fn buildReadConfigCdb(image_index: u8) [6]u8 {
+    return .{
+        0xE0,
+        image_index,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+    };
+}
+
+pub fn readConfig(device_path: []const u8, image_index: u8) ConfigError!ConfigReadResult {
+    if (image_index >= IMAGE_COUNT) {
+        return ConfigError.InvalidImageIndex;
+    }
+
+    var buffer: [CONFIG_SIZE]u8 = [_]u8{0} ** CONFIG_SIZE;
+    const cdb = buildReadConfigCdb(image_index);
+    const result = sg_io.execute(device_path, &cdb, &buffer, .from_dev, sg_io.DEFAULT_TIMEOUT_MS) catch |err| {
+        return switch (err) {
+            sg_io.SgError.PermissionDenied => ConfigError.PermissionDenied,
+            sg_io.SgError.InvalidDevice => ConfigError.DeviceNotFound,
+            sg_io.SgError.Timeout => ConfigError.Timeout,
+            else => ConfigError.CommandFailed,
+        };
+    };
+
+    if (!result.success) {
+        return ConfigError.CommandFailed;
+    }
+
+    if (result.bytes_transferred < CONFIG_SIZE) {
+        return ConfigError.ShortRead;
+    }
+
+    return ConfigReadResult{
+        .image_index = image_index,
+        .data = buffer,
+        .duration_ms = result.duration_ms,
+        .scsi_status = result.status,
+    };
+}
+
+pub fn printConfigHuman(result: *const ConfigReadResult) void {
+    std.debug.print("Bridge Config Image {d} ({d} bytes)\n", .{ result.image_index, CONFIG_SIZE });
+    std.debug.print("Result: SCSI status={s}, duration={d}ms\n", .{
+        @tagName(result.scsi_status),
+        result.duration_ms,
+    });
+    std.debug.print("Notable bytes:\n", .{});
+    std.debug.print("  [0x7D] = 0x{x:0>2}\n", .{result.data[0x7D]});
+    std.debug.print("\nHex dump:\n", .{});
+
+    for (0..CONFIG_SIZE) |i| {
+        if (i % 16 == 0) {
+            std.debug.print("  {x:0>4}: ", .{i});
+        }
+        std.debug.print("{x:0>2} ", .{result.data[i]});
+        if (i % 16 == 15) {
+            std.debug.print("\n", .{});
+        }
+    }
+}
+
+pub fn printConfigJson(result: *const ConfigReadResult) void {
+    const stdout = std.io.getStdOut().writer();
+    stdout.print(
+        "{{\n  \"image_index\": {},\n  \"duration_ms\": {},\n  \"byte_7d\": \"0x{x:0>2}\",\n  \"data_hex\": \"",
+        .{ result.image_index, result.duration_ms, result.data[0x7D] },
+    ) catch return;
+
+    for (result.data) |byte| {
+        stdout.print("{x:0>2}", .{byte}) catch return;
+    }
+
+    stdout.print("\"\n}}\n", .{}) catch return;
+}
+
+test "build READ CONFIG CDB" {
+    const cdb0 = buildReadConfigCdb(0);
+    try std.testing.expectEqual(@as(u8, 0xE0), cdb0[0]);
+    try std.testing.expectEqual(@as(u8, 0x00), cdb0[1]);
+    try std.testing.expectEqual(@as(usize, 6), cdb0.len);
+
+    const cdb1 = buildReadConfigCdb(1);
+    try std.testing.expectEqual(@as(u8, 0x01), cdb1[1]);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,13 +15,14 @@ const std = @import("std");
 const sg_io = @import("scsi/sg_io.zig");
 const sense = @import("scsi/sense.zig");
 const passthrough = @import("asm2362/passthrough.zig");
+const config = @import("asm2362/config.zig");
 const commands = @import("asm2362/commands.zig");
 const xram = @import("asm2362/xram.zig");
 const identify = @import("nvme/identify.zig");
 const probe = @import("analysis/probe.zig");
 const replay = @import("frida/replay.zig");
 
-pub const std_options = .{
+pub const std_options: std.Options = .{
     .log_level = .info,
 };
 
@@ -29,6 +30,7 @@ const Command = enum {
     probe,
     identify,
     smart,
+    config_read,
     replay,
     get_features,
     set_features,
@@ -66,6 +68,7 @@ const Args = struct {
     feature_id: u8, // NVMe Feature ID (e.g., 0x84 for write protect)
     feature_value: u32, // Value to set for Set Features
     save_feature: bool, // Persist feature across power cycles
+    config_image: u8, // ASM2362 config image index (0 or 1)
     // Security args
     security_protocol: u8, // Security protocol (0x00=info, 0xEF=ATA password)
     sp_specific: u16, // Protocol-specific value
@@ -101,6 +104,7 @@ fn parseArgs(allocator: std.mem.Allocator) !Args {
         .feature_id = 0x84,
         .feature_value = 0,
         .save_feature = false,
+        .config_image = 0,
         .security_protocol = 0x00,
         .sp_specific = 0,
         .xram_address = 0xB000,
@@ -139,6 +143,8 @@ fn parseArgs(allocator: std.mem.Allocator) !Args {
             result.command = .identify;
         } else if (std.mem.eql(u8, arg, "smart")) {
             result.command = .smart;
+        } else if (std.mem.eql(u8, arg, "config-read")) {
+            result.command = .config_read;
         } else if (std.mem.eql(u8, arg, "replay")) {
             result.command = .replay;
             if (i + 1 < args.len) {
@@ -159,6 +165,8 @@ fn parseArgs(allocator: std.mem.Allocator) !Args {
             result.feature_value = std.fmt.parseInt(u32, arg[8..], 0) catch 0;
         } else if (std.mem.eql(u8, arg, "--save")) {
             result.save_feature = true;
+        } else if (std.mem.startsWith(u8, arg, "--image=")) {
+            result.config_image = std.fmt.parseInt(u8, arg[8..], 0) catch 0;
         } else if (std.mem.startsWith(u8, arg, "--protocol=")) {
             result.security_protocol = std.fmt.parseInt(u8, arg[11..], 0) catch 0;
         } else if (std.mem.startsWith(u8, arg, "--sp-specific=")) {
@@ -230,6 +238,7 @@ fn printUsage() void {
         \\    probe         Probe device capabilities and identify bridge type
         \\    identify      Get NVMe Identify Controller/Namespace data
         \\    smart         Get NVMe SMART/Health log
+        \\    config-read   Read ASM2362 bridge configuration image (0xE0)
         \\
         \\XRAM COMMANDS (bypass 0xe6 whitelist via direct bridge XRAM access):
         \\    xram-probe    Probe XRAM capabilities (safe, read-only)
@@ -267,6 +276,7 @@ fn printUsage() void {
         \\
         \\PASSTHROUGH OPTIONS:
         \\    --fid=N          Feature ID for get/set-features (default: 0x84)
+        \\    --image=N        Config image index for config-read (0 or 1, default: 0)
         \\    --value=N        Value for set-features
         \\    --save           Save feature persistently
         \\    --protocol=N     Security protocol (0x00=info, 0xEF=ATA password)
@@ -276,6 +286,7 @@ fn printUsage() void {
         \\EXAMPLES:
         \\    asm2362-tool probe /dev/sdb                              # Safe: detect bridge
         \\    asm2362-tool smart /dev/sdb --json                       # Safe: read SMART
+        \\    asm2362-tool config-read /dev/sdb --image=0              # Read config image 0
         \\    asm2362-tool xram-probe /dev/sdb                         # Safe: probe XRAM
         \\    asm2362-tool xram-dump --addr=0xB000 --len=512 /dev/sdb  # Dump Admin SQ
         \\    asm2362-tool xram-dump --addr=0xB200 --len=256 /dev/sdb  # Dump MMIO regs
@@ -329,6 +340,17 @@ pub fn main() !void {
         },
         .smart => {
             try commands.getSmartLog(allocator, device_path, args.json_output);
+        },
+        .config_read => {
+            const result = config.readConfig(device_path, args.config_image) catch |err| {
+                std.debug.print("Config read failed: {s}\n", .{@errorName(err)});
+                std.process.exit(1);
+            };
+            if (args.json_output) {
+                config.printConfigJson(&result);
+            } else {
+                config.printConfigHuman(&result);
+            }
         },
         .replay => {
             const replay_file = args.replay_file orelse {


### PR DESCRIPTION
## Summary

This branch adds two small pieces of ASM2362 tooling and documents later post-recovery failure modes that are distinct from the original controller-protection / medium-absent work.

What changed:
- add `asm2362-tool config-read` support for reading the `0xE0` bridge config surface
- add `scripts/analysis/capture-asm2362-descriptors.sh` for capturing live USB descriptor state during field investigation
- add `docs/notes/darwin-post-recovery-integration.md`
- add `docs/notes/usb-link-negotiation-field-report-2026-04.md`
- update `README.md` and `docs/INDEX.md` to point at the newer notes

## Why

The repo already covered the original recovery lane and the later Darwin automation / access-policy lane. April 2026 retests turned up a third failure class:

- the ASM2362 still advertised SuperSpeed and SuperSpeedPlus capability
- the enclosure and media still looked operational from Linux read-only probes
- but multiple earlier host/cable paths negotiated only `480Mbps`

A later `petting-zoo-mini` retest with a dedicated SuperSpeed-rated USB-C cable changed the result:

- the ASM236X enclosure negotiated `10Gbps (SuperSpeed+)`
- bounded APFS stack probes resolved the volume, container, and physical store cleanly
- `/Volumes/TinylandSSD/tinyland` passed write/read/delete smoke

That means the pzm failure mode is best classified as cable class / signal-path failure before firmware mutation, not a global firmware lock to USB 2.0.

Related:
- References #17
- Updates #22
- Linear: TIN-99

## Validation

Local build/test from the earlier tooling tranche:
- `zig build`
- `zig build test-all`

Live read-only field probes on Linux (`/dev/sda` on the degraded `480Mbps` path):
- `asm2362-tool probe /dev/sda`
- `asm2362-tool config-read /dev/sda --image=0`
- `asm2362-tool config-read /dev/sda --image=1`
- `asm2362-tool xram-probe /dev/sda`
- `asm2362-tool identify /dev/sda` (expected `InvalidCommand` on this path)
- `asm2362-tool smart /dev/sda --json` (expected `InvalidCommand` on this path)
- `smartctl -d sntasmedia -i -H /dev/sda` (expected unsupported opcode on this path)

Live pzm follow-up evidence:
- `just pzm-ssd-transport-status`: expected ASM236X fingerprint at `10Gbps (SuperSpeed+)`
- bounded pzm stack probe: volume/container/physical-store metadata all returned successfully
- pzm SSD smoke: write/read/delete under `/Volumes/TinylandSSD/tinyland` passed

Docs-only update validation:
- `git diff --check`